### PR TITLE
Change potentially system-wrecking pacman command in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,9 @@ To install Haskell 7.8x from the unofficial repo (Fedora 21+ will include it in 
 
 ### Arch Linux
 
-To install Haskell from the official repos on Arch Linux
+To install Haskell from the official repos on Arch Linux, run
 
-Update your mirrorlist
-- `sudo pacman -Syy`
-
-Download Haskell
-- `sudo pacman -S cabal-install ghc happy alex haddock`
+    su -c "pacman -S cabal-install ghc happy alex haddock"
 
 ### Mac OS X
 


### PR DESCRIPTION
The README had a pacman command (`-Syy`, to be specific), which could break one's system if not used carefully.

A guy named "Allan" explained why in this [BBS thread](https://bbs.archlinux.org/viewtopic.php?id=89328).

> It can create dependency issues as Arch is designed only to have the latest versions of packages installed. e.g. enable testing and install the latest firefox with "pacman -Sy firefox"...  that will pull in the new versions of libjpeg and libpng which will break a lot of your applications that still require the old version.   Updating all packages avoids that issue.
> Issues with graphical packages is not so bad, but people got themselves into major trouble when updating readline (broken bash...)
