### PR TITLE
Added links to Chris Done's HIndent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Useful for understanding `Functor`, `Applicative`, `Monad`, `Monoid` and other t
 
 - https://github.com/bitemyapp/dotfiles/
 
+- https://github.com/chrisdone/hindent
+
 ### Vim
 
 - http://www.haskell.org/haskellwiki/Vim
@@ -235,6 +237,8 @@ Useful for understanding `Functor`, `Applicative`, `Monad`, `Monoid` and other t
 - https://github.com/kazu-yamamoto/ghc-mod
 
 - https://github.com/eagletmt/ghcmod-vim
+
+- https://github.com/chrisdone/hindent
 
 ### Sublime Text
 


### PR DESCRIPTION
HIndent (https://github.com/chrisdone/hindent/) is a wonderful Haskell
pretty-printer. It takes the tedium out of doing indentation in Haskell. Highly
recommend. It includes a vim extension (or whatever it's called) and an Emacs
minor mode.

It is not included in any of the links in the README. I opened an issue on the
Emacs Haskell
tutorial (https://github.com/serras/emacs-haskell-tutorial/issues/20), but this
can serve as a temporary patch for the time being.
