### PR TITLE
Fix pandoc/latex issue with unicode chars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ TITLE = -V title=LearnHaskell
 AUTHOR = -V author=bitemyapp
 FONTSIZE = -V fontsize=12pt
 FONTFAMILY = -V fontfamily=sans
+MAINFONT= -V mainfont=Georgia
 PAGESIZE = -V pagesize=a4paper
 GEOMETRY = -V geometry=landscape
-VARIABLES = $(GEOMETRY) $(FONTSIZE) $(PAGESIZE) $(TITLE) $(AUTHOR) $(FONTFAMILY)
-FLAGS = --normalize --smart --toc $(VARIABLES)
+VARIABLES = $(GEOMETRY) $(FONTSIZE) $(PAGESIZE) $(TITLE) $(AUTHOR) $(FONTFAMILY) $(MAINFONT)
+FLAGS = --normalize --smart --toc --latex-engine=xelatex $(VARIABLES)
 
 pdf: README.md
 	$(PANDOC) -s $(INPUT) -o $(OUTPUT) $(FLAGS) --column=80


### PR DESCRIPTION
I had troubles getting "make pdf" to compile, due to special unicode characters.
Following the [pandoc example n. 14] (http://johnmacfarlane.net/pandoc/demos.html), it finally worked.

Though, I had to specify a font that correctly rendered the unicode characters (I picked Georgia as per the aforementioned example).