### PR TITLE
Rename Hacker Shcool to Recurse Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Don't describe things as "easy" or "trivial". You'll making people feel terrible
 
 No feigning surprise. Don't act surprised when somebody says they don't know something. They'll feel terrible and you've accomplished nothing except to make yourself feel sharp.
 
-No well-actually's. When someone says something that's almost - but not entirely - correct, and you say, "well, actually…" and then give a minor correction. This is especially annoying when the correction has no bearing on the actual conversation. This doesn't mean Hacker School isn't about truth-seeking or that we don't care about being precise. Almost all well-actually's are about grandstanding, not truth-seeking.
+No well-actually's. When someone says something that's almost - but not entirely - correct, and you say, "well, actually…" and then give a minor correction. This is especially annoying when the correction has no bearing on the actual conversation. This doesn't mean Recurse Center isn't about truth-seeking or that we don't care about being precise. Almost all well-actually's are about grandstanding, not truth-seeking.
 
 No back-seat driving. If you see people working through a problem, you shouldn't intermittently interject advice. Let them work it out unless someone asks for help. Avoiding interruptions is [one of the founding purposes of #haskell-beginners](http://chrisdone.com/posts/teaching). 
 
@@ -50,7 +50,7 @@ No subtle -isms. Racism, sexism, homophobia, transphobia, and other kinds of bia
 
 ---
 
-Guidelines by [the Hacker School manual](https://www.hackerschool.com/manual). Thanks for releasing it Hacker School.
+Guidelines by [the Recurse Center manual](https://www.recurse.com/manual). Thanks for releasing it Recurse Center.
 
 # What are Haskell, GHC, and Cabal?
 
@@ -142,7 +142,7 @@ the official one):
 
 ```bash
 $ sudo yum-config-manager --add-repo \
-> https://copr.fedoraproject.org/coprs/petersen/ghc-7.8.4/repo/fedora-21/petersen-ghc-7.8.4-fedora-21.repo 
+> https://copr.fedoraproject.org/coprs/petersen/ghc-7.8.4/repo/fedora-21/petersen-ghc-7.8.4-fedora-21.repo
 $ sudo yum install ghc cabal-install
 ```
 

--- a/guide-de.md
+++ b/guide-de.md
@@ -28,7 +28,7 @@ Langsame Lerner sind meistens die sorgfältigsten, das sollte gewürdigt werden!
 Keine geheuchelte Überraschung. Spiele nicht überrascht, wenn jemand sagt, dass er etwas nicht weiß. Du erreichst nur, dass jemand sicht schlecht fühlt und du dich besonders toll.
 
 Kein "also, eigentlich ...". Wenn jemand etwas sagt, das nahezu richtig ist - aber nicht exakt - und du sagst, "also, eigentlich..." und gibst eine kleine Korrektur. Das ist
-besonders unnötig, da es keine Nutzen für die eigentlich Konversation hat. Das heißt nicht, dass die Hacker School nicht an Richtigkeit oder Genauigkeit interessiert ist.
+besonders unnötig, da es keine Nutzen für die eigentlich Konversation hat. Das heißt nicht, dass die Recurse Center nicht an Richtigkeit oder Genauigkeit interessiert ist.
 Fast alle "also, eigentlich" sind Selbstdarstellung und keine konstruktiven Verbesserungen.
 
 Kein ständiges Reinreden. Wenn du siehst wie jemand ein Problem durcharbeitet, sollest du nicht immer wieder Vorschläge einwerfen. Lass es ihn herausfinden außer er fragt
@@ -38,7 +38,7 @@ Rassismus, Sexismus, Homophobie, Transphobie und andere Arten von Vorurteilen si
 
 ---
 
-Richtlinien aus [the Hacker School manual](https://www.hackerschool.com/manual). Danke für die Veröffentlichung Hacker School.
+Richtlinien aus [the Recurse Center manual](https://www.recurse.com/manual). Danke für die Veröffentlichung Recurse Center.
 
 # Was sind Haskell, GHC, und Cabal?
 

--- a/guide-fr.md
+++ b/guide-fr.md
@@ -25,7 +25,7 @@ Ne décrivez pas quelquechose comme "facile" ou "trivial". Vous créeriez un mal
 
 Ne pas feindre la surprise. N'ayez pas l'air surpris lorsque quelqu'un affirme ne pas savoir quelque chose. La personne se sentira mal et vous n'aurez rien accompli mis à part flatter votre égo.
 
-Pas de "en fait…". Lorsqu'une personne dit quelque chose de presque - mais pas entièrement - correct, et vous répondez, "Ouais… en fait…" puis les corrigez. C'est particulièrement gênant lorsque la correction n'a aucune incidence sur la conversation actuelle. Cela ne signifie pas que Hacker School ne se soucie pas de la recherche de la vérité ou que nous ne nous soucions pas d'être précis. Presque tous les "Ouais… en fait…" sont un moyen de se mettre en valeur, et non de la recherche de la vérité.
+Pas de "en fait…". Lorsqu'une personne dit quelque chose de presque - mais pas entièrement - correct, et vous répondez, "Ouais… en fait…" puis les corrigez. C'est particulièrement gênant lorsque la correction n'a aucune incidence sur la conversation actuelle. Cela ne signifie pas que Recurse Center ne se soucie pas de la recherche de la vérité ou que nous ne nous soucions pas d'être précis. Presque tous les "Ouais… en fait…" sont un moyen de se mettre en valeur, et non de la recherche de la vérité.
 
 Pas de conduite accompagnée. Si vous voyez des personnes buter sur un problème, vous ne devez pas immédiatement donner des conseils. Laissez travailler dessus à moins que quelqu'un demande de l'aide. Eviter les interruptions est [un des objectifs fondateurs du canal #haskell-beginners](http://chrisdone.com/posts/teaching).
 
@@ -33,7 +33,7 @@ Pas de -ismes. Racisme, sexisme, homophobie, transphobie, et autres biais ne son
 
 ---
 
-Recommandations du [manuel de the Hacker School](https://www.hackerschool.com/manual). Merci de l'avoir publié Hacker School.
+Recommandations du [manuel de the Recurse Center](https://www.recurse.com/manual). Merci de l'avoir publié Recurse Center.
 
 # Qu'est ce que Haskell, GHC, et Cabal?
 


### PR DESCRIPTION
Hacker School is now Recurse Center
https://www.recurse.com/blog/77-hacker-school-is-now-the-recurse-center