### PR TITLE
"Monad Transformers Step by Step" link updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Comment from Reddit thread by `glaebhoerl`
 Implement the standard library monads ( List, Maybe, Cont, Error, Reader,
 Writer, State ) for yourself to understand them better. Then maybe write an
 monadic interpreter for a small expression language using
-[Monad Transformers Step by Step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf)
+[Monad Transformers Step by Step](http://catamorph.de/documents/Transformers.pdf)
 paper (mentioned in 'monad transformers' below).
 
 Writing many interpreters by just changing the monad to change the semantics can
@@ -410,7 +410,7 @@ Credits:
 
 - [A gentle introduction to Monad Transformers](https://github.com/kqr/gists/blob/master/articles/gentle-introduction-monad-transformers.md).
 
-- [Monad transformers step-by-step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf) (warning, code out of date).
+- [Monad transformers step-by-step](http://catamorph.de/documents/Transformers.pdf).
 
 # Testing, tests, specs, generative/property testing
 

--- a/guide-de.md
+++ b/guide-de.md
@@ -410,7 +410,7 @@ Original:
 Implementiere die Monaden aus der Standard Bibliothek ( List, Maybe, Cont, Error, Reader,
 Writer, State ) für dich selbst, um sie besser zu verstehen. Dann schreibe vielleicht einen
 monadischen Interpreter für eine kleine Expression Sprache mit dem
-[Monad Transformers Step by Step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf)
+[Monad Transformers Step by Step](http://catamorph.de/documents/Transformers.pdf)
 Paper (erwähnt in 'monad transformers' im folgenden).
 
 Mehrere Interpreter zu schreiben, indem man einfach nur die Monade ändert um die Semantik zu verändern
@@ -432,10 +432,10 @@ Credits:
 - Reddit Kommentar von jozefg [hier](http://www.reddit.com/r/haskell/comments/29eke6/basic_program_ideas_for_learning_about_monads/cik5trg).
 
 ## Monad transformers
-
+ 
 - [A gentle introduction to Monad Transformers](https://github.com/kqr/gists/blob/master/articles/gentle-introduction-monad-transformers.md).
 
-- [Monad transformers step-by-step](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf) (warning, code out of date).
+- [Monad transformers step-by-step](http://catamorph.de/documents/Transformers.pdf).
 
 # Testen, Tests, Specs, generative/property testing
 

--- a/guide-fr.md
+++ b/guide-fr.md
@@ -370,7 +370,7 @@ Implémenter les monades de la librairie standard (List, Maybe, Cont, Error,
 Reader, Writer, State) par vous-même afin de mieux les comprendre. Après, vous
 pouvez peut-être écrire un interpréteur monadique pour un langage avec des petites
 expressions en utilisant le papier sur les
-[transformateurs de monades étape par étape](http://www.cs.virginia.edu/~wh5a/personal/Transformers.pdf)
+[transformateurs de monades étape par étape](http://catamorph.de/documents/Transformers.pdf)
 (mentionné dans la section "transformateurs de monades" ci-dessous).
 
 Écrire plusieurs interpréteurs en changeant juste le Monde pour changer les
@@ -401,7 +401,7 @@ Crédits:
 de Kazu Yamamoto est fantastique.
 
 - [Simple-Conduit](https://github.com/jwiegley/simple-conduit): Une bonne librairie simple pour apprendre comment le streaming d'IO fonctionne en général. Les connaissances acquises ici sont transférables à Pipes et Conduit.
-
+ 
 # Parsing en Haskell
 
 - [Tutoriel](https://github.com/JakeWheat/intro_to_parsing) sur les parser


### PR DESCRIPTION
So, the author of the paper, Martin Grabmüller, put up a version with code changes in 2012 by Gábor Lipták.  Also, the literate haskell version is [here](http://catamorph.de/documents/Transformers.lhs).