### PR TITLE
Bump GHC and Cabal versions in Ubuntu install instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -34,13 +34,13 @@ $ sudo apt-get install python-software-properties # v12.04 and below
 $ sudo apt-get install software-properties-common # v12.10 and above
 $ sudo add-apt-repository -y ppa:hvr/ghc
 $ sudo apt-get update
-$ sudo apt-get install cabal-install-1.22 ghc-7.8.4 happy-1.19.5 alex-3.1.4
+$ sudo apt-get install cabal-install-1.24 ghc-7.10.3 happy-1.19.5 alex-3.1.4
 ```
 
 Then prepend the following to your `$PATH` (bash\_profile, zshrc, bashrc, etc):
 
 ```
-export PATH=~/.cabal/bin:/opt/cabal/1.22/bin:/opt/ghc/7.8.4/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH
+export PATH=~/.cabal/bin:/opt/cabal/1.24/bin:/opt/ghc/7.10.3/bin:/opt/happy/1.19.5/bin:/opt/alex/3.1.4/bin:$PATH
 ```
 
 *Optional:* You could also add `.cabal-sandbox/bin` to your path. Code that you


### PR DESCRIPTION
Not sure if there's a reason the install instructions were on 7.8, but I noticed the book is referencing 7.10 so thought perhaps it should be updated?