### PR TITLE
linux distribution install guide correction

### DIFF
--- a/guide-de.md
+++ b/guide-de.md
@@ -152,10 +152,8 @@ via Portage installieren. Wenn du `ACCEPT_KEYWORDS=arch` nutzt (anstatt
 Haskell Teile. Daher füge, wenn du, und *nur* wenn du `ACCEPT_KEYWORDS=arch` nutzt, das
 Folgende in `/etc/portage/package.accept_keywords` ein.
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 Wenn das getan ist:
 

--- a/guide-de.md
+++ b/guide-de.md
@@ -150,10 +150,12 @@ Unter Gentoo kannst du verschiedene Komponenten der Haskell Platform
 via Portage installieren. Wenn du `ACCEPT_KEYWORDS=arch` nutzt (anstatt
 `ACCEPT_KEYWORDS=~arch`), installiert Portage die uralt Versionen der verschiedenen
 Haskell Teile. Daher füge, wenn du, und *nur* wenn du `ACCEPT_KEYWORDS=arch` nutzt, das
-Folgende in `/etc/portage/package.keywords` ein.
+Folgende in `/etc/portage/package.accept_keywords` ein.
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 Wenn das getan ist:
 

--- a/guide-fr.md
+++ b/guide-fr.md
@@ -146,10 +146,8 @@ composants Haskell. Maintenant que vous avez ça en tête, si et seulement si vo
 utilisez `ACCEPT_KEYWORDS=arch`, ajoutez ce qui suit à
 `/etc/portage/package.accept_keywords`.
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 Une fois que cela est fait,
 

--- a/guide-fr.md
+++ b/guide-fr.md
@@ -144,10 +144,12 @@ Haskell depuis Portage. Si vous utilisez `ACCEPT_KEYWORDS=arch` (par opposition 
 `ACCEPT_KEYWORDS=~arch`), Portage installera d'anciennes versions des différents
 composants Haskell. Maintenant que vous avez ça en tête, si et seulement si vous
 utilisez `ACCEPT_KEYWORDS=arch`, ajoutez ce qui suit à
-`/etc/portage/package.keywords`.
+`/etc/portage/package.accept_keywords`.
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 Une fois que cela est fait,
 

--- a/guide-it.md
+++ b/guide-it.md
@@ -151,10 +151,8 @@ Su Gentoo, potete installare i singoli componenti della Haskell Platform
 attraverso Portage. Se usate `ACCEPT_KEYWORDS=arch` (invece che
 `ACCEPT_KEYWORDS=~arch`), Portage installerà versioni più vecchie di Haskell. Tenendone di conto, se usate `ACCEPT_KEYWORDS=arch`, aggiungete le seguenti linee a `/etc/portage/package.accept_keywords`.
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 Una volta fatto quello, lanciate:
 

--- a/guide-it.md
+++ b/guide-it.md
@@ -149,10 +149,12 @@ $ sudo pacman -S cabal-install ghc happy alex haddock
 
 Su Gentoo, potete installare i singoli componenti della Haskell Platform
 attraverso Portage. Se usate `ACCEPT_KEYWORDS=arch` (invece che
-`ACCEPT_KEYWORDS=~arch`), Portage installerà versioni più vecchie di Haskell. Tenendone di conto, se usate `ACCEPT_KEYWORDS=arch`, aggiungete le seguenti linee a `/etc/portage/package.keywords`.
+`ACCEPT_KEYWORDS=~arch`), Portage installerà versioni più vecchie di Haskell. Tenendone di conto, se usate `ACCEPT_KEYWORDS=arch`, aggiungete le seguenti linee a `/etc/portage/package.accept_keywords`.
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 Una volta fatto quello, lanciate:
 

--- a/guide-ru.md
+++ b/guide-ru.md
@@ -185,10 +185,8 @@ $ sudo pacman -S cabal-install ghc happy alex haddock
 Если вы используете `ACCEPT_KEYWORDS=arch` (вместо `ACCEPT_KEYWORDS=~arch`),
 Portage установит древние версии различных компонент Haskell. Помня это, если вы используете `ACCEPT_KEYWORDS=arch`, добавьте следующие строки в `/etc/portage/package.accept_keywords`.
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 Как только это сделано,
 

--- a/guide-ru.md
+++ b/guide-ru.md
@@ -183,10 +183,12 @@ $ sudo pacman -S cabal-install ghc happy alex haddock
 
 На Gentoo вы можете установить индивидуальные компоненты Haskell Platform через Portage.
 Если вы используете `ACCEPT_KEYWORDS=arch` (вместо `ACCEPT_KEYWORDS=~arch`),
-Portage установит древние версии различных компонент Haskell. Помня это, если вы используете `ACCEPT_KEYWORDS=arch`, добавьте следующие строки в `/etc/portage/package.keywords`.
+Portage установит древние версии различных компонент Haskell. Помня это, если вы используете `ACCEPT_KEYWORDS=arch`, добавьте следующие строки в `/etc/portage/package.accept_keywords`.
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 Как только это сделано,
 

--- a/guide-zh_tw.md
+++ b/guide-zh_tw.md
@@ -124,8 +124,10 @@ $ sudo pacman -S cabal-install ghc happy alex haddock
 你可以透過Portage來分別安裝Haskell Platform的各個組件。如果你使用`ACCEPT_KEYWORDS=arch`，而非`ACCEPT_KETWORDS=~arch`，
 Portage會弄個老舊的Haskell給你。因此，舉凡用了`ACCEPT_KEYWORDS=arch`，請把下面這幾行加進去：
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 接著請執行：
 

--- a/guide-zh_tw.md
+++ b/guide-zh_tw.md
@@ -124,10 +124,8 @@ $ sudo pacman -S cabal-install ghc happy alex haddock
 你可以透過Portage來分別安裝Haskell Platform的各個組件。如果你使用`ACCEPT_KEYWORDS=arch`，而非`ACCEPT_KETWORDS=~arch`，
 Portage會弄個老舊的Haskell給你。因此，舉凡用了`ACCEPT_KEYWORDS=arch`，請把下面這幾行加進去：
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 接著請執行：
 

--- a/install.md
+++ b/install.md
@@ -116,10 +116,8 @@ through Portage. If you use `ACCEPT_KEYWORDS=arch` (as opposed to
 Haskell things. With that in mind, iff you use `ACCEPT_KEYWORDS=arch`, add the
 following to `/etc/portage/package.accept_keywords`.
 
-```bash
     dev-haskell/cabal-install ~arch
     dev-lang/ghc ~arch
-```
 
 Once that is done,
 

--- a/install.md
+++ b/install.md
@@ -114,10 +114,12 @@ On Gentoo, you can install the individual components of the Haskell Platform
 through Portage. If you use `ACCEPT_KEYWORDS=arch` (as opposed to
 `ACCEPT_KEYWORDS=~arch`), Portage will install ancient versions of the various
 Haskell things. With that in mind, iff you use `ACCEPT_KEYWORDS=arch`, add the
-following to `/etc/portage/package.keywords`.
+following to `/etc/portage/package.accept_keywords`.
 
-    dev-haskell/cabal-install
-    dev-lang/ghc
+```bash
+    dev-haskell/cabal-install ~arch
+    dev-lang/ghc ~arch
+```
 
 Once that is done,
 


### PR DESCRIPTION
configuration file package.keywords seems deprecated and file format is different